### PR TITLE
feat: rename plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# plugin-navigation
+# api-plugin-navigation
 
-[![npm (scoped)](https://img.shields.io/npm/v/@reactioncommerce/plugin-navigation.svg)](https://www.npmjs.com/package/@reactioncommerce/plugin-navigation)
-[![CircleCI](https://circleci.com/gh/reactioncommerce/plugin-navigation.svg?style=svg)](https://circleci.com/gh/reactioncommerce/plugin-navigation)
+[![npm (scoped)](https://img.shields.io/npm/v/@reactioncommerce/api-plugin-navigation.svg)](https://www.npmjs.com/package/@reactioncommerce/api-plugin-navigation)
+[![CircleCI](https://circleci.com/gh/reactioncommerce/api-plugin-navigation.svg?style=svg)](https://circleci.com/gh/reactioncommerce/api-plugin-navigation)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 
 ## Summary

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@reactioncommerce/plugin-navigation",
+  "name": "@reactioncommerce/api-plugin-navigation",
   "version": "0.0.0-development",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@reactioncommerce/plugin-navigation",
+  "name": "@reactioncommerce/api-plugin-navigation",
   "description": "Navigation plugin for the Reaction API",
   "version": "0.0.0-development",
   "main": "index.js",
@@ -7,12 +7,12 @@
   "engines": {
     "node": ">=12.14.1"
   },
-  "homepage": "https://github.com/reactioncommerce/plugin-navigation",
-  "url": "https://github.com/reactioncommerce/plugin-navigation",
+  "homepage": "https://github.com/reactioncommerce/api-plugin-navigation",
+  "url": "https://github.com/reactioncommerce/api-plugin-navigation",
   "email": "engineering@reactioncommerce.com",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/reactioncommerce/plugin-navigation.git"
+    "url": "git+https://github.com/reactioncommerce/api-plugin-navigation.git"
   },
   "author": {
     "name": "Reaction Commerce",
@@ -21,7 +21,7 @@
   },
   "license": "GPL-3.0",
   "bugs": {
-    "url": "https://github.com/reactioncommerce/plugin-navigation/issues"
+    "url": "https://github.com/reactioncommerce/api-plugin-navigation/issues"
   },
   "sideEffects": false,
   "dependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ import { NavigationItem, NavigationItemContent, NavigationItemData } from "./sim
 export default async function register(app) {
   await app.registerPlugin({
     label: "Navigation",
-    name: "reaction-navigation",
+    name: "navigation",
     version: pkg.version,
     i18n,
     collections: {


### PR DESCRIPTION
Resolves #3 

Rename this plugin from `plugin-navigation` to `api-plugin-navigation`.

This will create a new npm package with a v1.1.0, and this new package will need to be installed in reaction core.

We also need to deprecate the existing npm package.